### PR TITLE
fix: js-sdsl tree shaking not work

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,10 @@ module.exports = {
             {
                 test: /\.(png|jpg|gif)$/,
                 type: "asset",
+            },
+            {
+                include: path.resolve(__dirname, "node_modules/js-sdsl"),
+                sideEffects: false
             }
         ],
     },


### PR DESCRIPTION
<!--
Thank you for the pull request!

Please follow the contributing guidelines(CONTRIBUTING.md).

Please fill out the following form then we can review your pull request.
-->

## What is the current behavior?

Configure webpack.config.js to  make js-sdsl tree shaking work.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Configure webpack.config.js to  make js-sdsl tree shaking work.

<!-- What is the new behavior? -->

## Why did you make this change?

Configure webpack.config.js to  make js-sdsl tree shaking work.

<!-- Please describe the reason for this change. -->

### Checklist

<!-- Please check "x" in the box below to indicate that you have completed the task. -->

- [x] I'm not PR to the main branch.
- [x] Commit message was checked by commitlint.

### Additional information

<!-- Please add any additional information here. -->
